### PR TITLE
Sync puzzle on game start

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -42,6 +42,15 @@
                                      :max-line-length 120}))
   )
 
+(deftask run-fe []
+  (comp
+    (serve :dir "target/public")
+    (watch)
+    (reload)
+    (cljs :source-map true :optimizations :none)
+    (target)
+    (nightlight :port 4000 :url "http://localhost:3000")))
+
 (deftask run []
   (comp
     (serve :dir "target/public")

--- a/src/clj/hello_world/core.clj
+++ b/src/clj/hello_world/core.clj
@@ -18,12 +18,15 @@
   (def chsk-send!                    send-fn)
   (def connected-uids                connected-uids))
 
+(def sprites-state (atom nil))
+
 (defn- handle-message! [{:keys [id client-id ?data]}]
   (println :id id)
   (println :cl-id client-id)
   (println :data? ?data)
 
   (when (= id :aikakone/sprites-state)
+    (reset! sprites-state ?data)
     (doseq [uid (:any @connected-uids)]
       (println :uid uid)
       (when (not= client-id uid)

--- a/src/clj/hello_world/core.clj
+++ b/src/clj/hello_world/core.clj
@@ -32,7 +32,10 @@
       (doseq [uid (:any @connected-uids)]
         (println :uid uid)
         (when (not= client-id uid)
-          (chsk-send! uid [:aikakone/sprites-state ?data]))))))
+          (chsk-send! uid [:aikakone/sprites-state ?data]))))
+
+    :aikakone/game-start
+    (chsk-send! client-id [:aikakone/game-start @sprites-state])))
 
 (sente/start-chsk-router! ch-chsk handle-message!)
 

--- a/src/clj/hello_world/core.clj
+++ b/src/clj/hello_world/core.clj
@@ -25,12 +25,14 @@
   (println :cl-id client-id)
   (println :data? ?data)
 
-  (when (= id :aikakone/sprites-state)
-    (reset! sprites-state ?data)
-    (doseq [uid (:any @connected-uids)]
-      (println :uid uid)
-      (when (not= client-id uid)
-        (chsk-send! uid [:aikakone/sprites-state ?data])))))
+  (case id
+    :aikakone/sprites-state
+    (do
+      (reset! sprites-state ?data)
+      (doseq [uid (:any @connected-uids)]
+        (println :uid uid)
+        (when (not= client-id uid)
+          (chsk-send! uid [:aikakone/sprites-state ?data]))))))
 
 (sente/start-chsk-router! ch-chsk handle-message!)
 

--- a/src/clj/user.clj
+++ b/src/clj/user.clj
@@ -1,0 +1,15 @@
+(ns user
+  (:require [hello-world.core :as core]
+            ))
+
+(defonce server (atom nil))
+
+(defn stop-server []
+  (when-not (nil? @server)
+    ;; graceful shutdown: wait 100ms for existing requests to be finished
+    ;; :timeout is optional, when no timeout, stop immediately
+    (@server :timeout 100)
+    (reset! server nil)))
+
+(defn start-server []
+  (reset! server (core/-main)))

--- a/src/cljs/hello_world/core.cljs
+++ b/src/cljs/hello_world/core.cljs
@@ -16,10 +16,10 @@
   (/ puzzle-width-height row-col-num))
 (def button-sprite-sheet-width (atom nil))
 (def button-sprite-sheet-height (atom nil))
-(defn- get-button-width [sheet-width]
-  (/ sheet-width 3))
-(defn- get-button-height [sheet-height]
-  (/ sheet-height 2))
+(defn- get-button-width []
+  (/ @button-sprite-sheet-width 3))
+(defn- get-button-height []
+  (/ @button-sprite-sheet-height 2))
 
 (defn- randomly-execute-a-fn [f]
   (when (< (rand) 0.5) (f)))
@@ -36,16 +36,16 @@
     (.-load @util/game)
     "flip-buttons"
     "images/control-buttons.png"
-    (get-button-width @button-sprite-sheet-width)
-    (get-button-height @button-sprite-sheet-height)
+    (get-button-width)
+    (get-button-height)
     6))
 
 (defn- make-buttons-same-size-as-puzzle-piece! [sprite]
   (let [piece-width-height (get-piece-width-height (:puzzle-width-height @util/game-state))]
     (.setTo
       (.-scale sprite)
-      (/ piece-width-height (get-button-width @button-sprite-sheet-width))
-      (/ piece-width-height (get-button-height @button-sprite-sheet-height)))))
+      (/ piece-width-height (get-button-width))
+      (/ piece-width-height (get-button-height)))))
 
 (defn- create []
   (let [game-object-factory (.-add @util/game)

--- a/src/cljs/hello_world/core.cljs
+++ b/src/cljs/hello_world/core.cljs
@@ -1,6 +1,5 @@
 (ns hello-world.core
   (:require [goog.events :as events]
-            [hello-world.game :as game]
             [hello-world.web-socket :as web-sck]
             [nightlight.repl-server]
             [hello-world.util :as util]
@@ -34,6 +33,6 @@
         (swap! util/game-state assoc :piece-y-scale (/ (:puzzle-width-height @util/game-state)
                                                        @util/puzzle-image-height))
         (println "Puzzle image loaded")
-        (game/start-game!))))                                    ; start game after loading image
+        (web-sck/start-web-socket!))))                                    ; start game after loading image
   (set! (.-src buttons-img) "images/control-buttons.png")
   (println "loading images"))

--- a/src/cljs/hello_world/core.cljs
+++ b/src/cljs/hello_world/core.cljs
@@ -1,173 +1,10 @@
 (ns hello-world.core
   (:require [goog.events :as events]
+            [hello-world.game :as game]
             [hello-world.web-socket :as web-sck]
             [nightlight.repl-server]
             [hello-world.util :as util]
             ))
-
-(def puzzle-image-width (atom nil))
-(def puzzle-image-height (atom nil))
-(defn- left-margin [puzzle-width]
-  (/ (- (.-innerWidth js/window) puzzle-width) 2))
-(defn- top-margin [puzzle-height]
-  (/ (- (.-innerHeight js/window) puzzle-height) 4))
-(def row-col-num 5)
-(defn- get-piece-width-height [puzzle-width-height]
-  (/ puzzle-width-height row-col-num))
-(def button-sprite-sheet-width (atom nil))
-(def button-sprite-sheet-height (atom nil))
-(defn- get-button-width []
-  (/ @button-sprite-sheet-width 3))
-(defn- get-button-height []
-  (/ @button-sprite-sheet-height 2))
-
-(defn- randomly-execute-a-fn [f]
-  (when (< (rand) 0.5) (f)))
-
-(defn- preload []
-  (.spritesheet
-    (.-load @util/game)
-    "puzzle"
-    "images/puzzle-image.jpg"
-    (get-piece-width-height @puzzle-image-width)
-    (get-piece-width-height @puzzle-image-height)
-    (* row-col-num row-col-num))
-  (.spritesheet
-    (.-load @util/game)
-    "flip-buttons"
-    "images/control-buttons.png"
-    (get-button-width)
-    (get-button-height)
-    6))
-
-(defn- make-buttons-same-size-as-puzzle-piece! [sprite]
-  (let [piece-width-height (get-piece-width-height (:puzzle-width-height @util/game-state))]
-    (.setTo
-      (.-scale sprite)
-      (/ piece-width-height (get-button-width))
-      (/ piece-width-height (get-button-height)))))
-
-(defn- create []
-  (let [game-object-factory (.-add @util/game)
-        left-margin (left-margin (:puzzle-width-height @util/game-state))
-        top-margin (top-margin (:puzzle-width-height @util/game-state))
-        piece-width-height (get-piece-width-height (:puzzle-width-height @util/game-state))
-        set-on-click-callback! (fn [sprite callback-fn]
-                                 (set! (.-inputEnabled sprite) true)
-                                 (.add
-                                   (.-onInputDown (.-events sprite))
-                                   callback-fn))
-        toggle-visibility-and-flipped-state! (fn [col row]
-                                               (let [piece-scale (.-scale ((:sprites @util/game-state) [col row]))]
-                                                 (if (zero? (.-x piece-scale))
-                                                   (do
-                                                     (swap!
-                                                       util/game-state
-                                                       update
-                                                       :sprites-state
-                                                       assoc
-                                                       [col row]
-                                                       util/non-flipped-state)
-                                                     (.setTo
-                                                       piece-scale
-                                                       (:piece-x-scale @util/game-state)
-                                                       (:piece-y-scale @util/game-state)))
-                                                   (do
-                                                     (swap!
-                                                       util/game-state
-                                                       update
-                                                       :sprites-state
-                                                       assoc
-                                                       [col row]
-                                                       util/flipped-state)
-                                                     (.setTo piece-scale 0 0)))))]
-    (doseq [row (range row-col-num)
-            col (range row-col-num)
-            :let [frame-id (+ (* row-col-num row) col)
-                  x-pos (+ (* piece-width-height col) left-margin col)
-                  y-pos (+ (* piece-width-height row) top-margin row)]]
-      (let [piece (.sprite
-                    game-object-factory
-                    x-pos
-                    y-pos
-                    "puzzle"
-                    frame-id)]
-        (swap! util/game-state update :sprites assoc [col row] piece)
-        (swap! util/game-state update :sprites-state assoc [col row] util/non-flipped-state)
-        (.setTo (.-scale piece) (:piece-x-scale @util/game-state) (:piece-y-scale @util/game-state)))
-      (when
-        (and (zero? col) (= row (dec row-col-num)))
-        (let [bottom-left-button (.sprite
-                                   game-object-factory
-                                   (- x-pos piece-width-height)
-                                   (+ y-pos piece-width-height)
-                                   "flip-buttons"
-                                   5)
-              flip-diagonal-pieces! (fn []
-                                     (doseq [row (range row-col-num)
-                                             :let [col (- (dec row-col-num) row)]]
-                                       (toggle-visibility-and-flipped-state! col row)))]
-          (make-buttons-same-size-as-puzzle-piece! bottom-left-button)
-          (set-on-click-callback!
-            bottom-left-button
-            (fn []
-              (println "bottom-left-button clicked")
-              (flip-diagonal-pieces!)
-              (web-sck/send-sprites-state!)
-              (util/show-congrat-message-when-puzzle-is-complete!)))
-          (randomly-execute-a-fn flip-diagonal-pieces!)))
-      (when (zero? col)
-        (let [left-button (.sprite
-                                   game-object-factory
-                                   (- x-pos piece-width-height)
-                                   y-pos
-                                   "flip-buttons"
-                                   row)
-              flip-row! (fn []
-                          (doseq [col (range row-col-num)]
-                            (toggle-visibility-and-flipped-state! col row)))]
-          (make-buttons-same-size-as-puzzle-piece! left-button)
-          (set-on-click-callback!
-            left-button
-            (fn []
-              (println (str "left-button row #" row " clicked"))
-              (flip-row!)
-              (web-sck/send-sprites-state!)
-              (util/show-congrat-message-when-puzzle-is-complete!)))
-          (randomly-execute-a-fn (fn [] (js/setTimeout flip-row! 200)))))
-      (when (= row (dec row-col-num))
-        (let [bottom-button (.sprite
-                              game-object-factory
-                              x-pos
-                              (+ y-pos piece-width-height)
-                              "flip-buttons"
-                              col)
-              flip-col! (fn []
-                          (doseq [row (range row-col-num)]
-                            (toggle-visibility-and-flipped-state! col row)))]
-          (make-buttons-same-size-as-puzzle-piece! bottom-button)
-          (set-on-click-callback!
-            bottom-button
-            (fn []
-              (println (str "bottom-button col #" col " clicked"))
-              (flip-col!)
-              (web-sck/send-sprites-state!)
-              (util/show-congrat-message-when-puzzle-is-complete!)))
-          (randomly-execute-a-fn (fn [] (js/setTimeout flip-col! 200)))))))
-  (js/setTimeout web-sck/send-sprites-state! 300))
-
-(defn- update [])
-
-(defn- start-game! []
-  (println "starting game")
-  (reset! util/game
-          (js/Phaser.Game.
-            (.-innerWidth js/window)
-            (.-innerHeight js/window)
-            js/Phaser.Auto
-            ""
-            ; ^ id of the DOM element to insert canvas. As we've left it blank it will simply be appended to body.
-            (clj->js {:preload preload :create create :update update}))))
 
 ; this is the game program's entry point
 (let [puzzle-img (js/Image.)
@@ -180,23 +17,23 @@
     (.-onload buttons-img)
     (clj->js
       (fn []
-        (reset! button-sprite-sheet-width (.-width buttons-img))
-        (reset! button-sprite-sheet-height (.-height buttons-img))
+        (reset! util/button-sprite-sheet-width (.-width buttons-img))
+        (reset! util/button-sprite-sheet-height (.-height buttons-img))
         (println "buttons image loaded")
         (set! (.-src puzzle-img) "images/puzzle-image.jpg"))))
   (set!
     (.-onload puzzle-img)
     (clj->js
       (fn []
-        (reset! puzzle-image-width (.-width puzzle-img))
-        (reset! puzzle-image-height (.-height puzzle-img))
+        (reset! util/puzzle-image-width (.-width puzzle-img))
+        (reset! util/puzzle-image-height (.-height puzzle-img))
         (swap! util/game-state assoc :puzzle-width-height (int (* 0.7 (min (.-innerWidth js/window)
                                                                            (.-innerHeight js/window)))))
         (swap! util/game-state assoc :piece-x-scale (/ (:puzzle-width-height @util/game-state)
-                                                       @puzzle-image-width))
+                                                       @util/puzzle-image-width))
         (swap! util/game-state assoc :piece-y-scale (/ (:puzzle-width-height @util/game-state)
-                                                       @puzzle-image-height))
+                                                       @util/puzzle-image-height))
         (println "Puzzle image loaded")
-        (start-game!))))                                    ; start game after loading image
+        (game/start-game!))))                                    ; start game after loading image
   (set! (.-src buttons-img) "images/control-buttons.png")
   (println "loading images"))

--- a/src/cljs/hello_world/core.cljs
+++ b/src/cljs/hello_world/core.cljs
@@ -155,7 +155,7 @@
               (web-sck/send-sprites-state!)
               (util/show-congrat-message-when-puzzle-is-complete!)))
           (randomly-execute-a-fn (fn [] (js/setTimeout flip-col! 200)))))))
-  (web-sck/send-sprites-state!))
+  (js/setTimeout web-sck/send-sprites-state! 300))
 
 (defn- update [])
 

--- a/src/cljs/hello_world/core.cljs
+++ b/src/cljs/hello_world/core.cljs
@@ -21,6 +21,9 @@
 (defn- get-button-height [sheet-height]
   (/ sheet-height 2))
 
+(defn- randomly-execute-a-fn [f]
+  (when (< (rand) 0.5) (f)))
+
 (defn- preload []
   (.spritesheet
     (.-load @util/game)
@@ -78,9 +81,7 @@
                                                        assoc
                                                        [col row]
                                                        util/flipped-state)
-                                                     (.setTo piece-scale 0 0)))))
-        randomly-execute-a-fn (fn [f]
-                                (when (< (rand) 0.5) (f)))]
+                                                     (.setTo piece-scale 0 0)))))]
     (doseq [row (range row-col-num)
             col (range row-col-num)
             :let [frame-id (+ (* row-col-num row) col)

--- a/src/cljs/hello_world/core.cljs
+++ b/src/cljs/hello_world/core.cljs
@@ -153,7 +153,8 @@
               (flip-col!)
               (web-sck/send-sprites-state!)
               (util/show-congrat-message-when-puzzle-is-complete!)))
-          (randomly-execute-a-fn (fn [] (js/setTimeout flip-col! 200))))))))
+          (randomly-execute-a-fn (fn [] (js/setTimeout flip-col! 200)))))))
+  (web-sck/send-sprites-state!))
 
 (defn- update [])
 

--- a/src/cljs/hello_world/core.cljs
+++ b/src/cljs/hello_world/core.cljs
@@ -44,15 +44,14 @@
   (let [game-object-factory (.-add @util/game)
         left-margin (left-margin (:puzzle-width-height @util/game-state))
         top-margin (top-margin (:puzzle-width-height @util/game-state))
-        piece-width (get-piece-width-height (:puzzle-width-height @util/game-state))
-        piece-height (get-piece-width-height (:puzzle-width-height @util/game-state))
+        piece-width-height (get-piece-width-height (:puzzle-width-height @util/game-state))
         button-width (get-button-width @button-sprite-sheet-width)
         button-height (get-button-height @button-sprite-sheet-height)
         make-buttons-same-size-as-puzzle-piece! (fn [sprite]
                                                   (.setTo
                                                     (.-scale sprite)
-                                                    (/ piece-width button-width)
-                                                    (/ piece-height button-height)))
+                                                    (/ piece-width-height button-width)
+                                                    (/ piece-width-height button-height)))
         set-on-click-callback! (fn [sprite callback-fn]
                                  (set! (.-inputEnabled sprite) true)
                                  (.add
@@ -85,8 +84,8 @@
     (doseq [row (range row-col-num)
             col (range row-col-num)
             :let [frame-id (+ (* row-col-num row) col)
-                  x-pos (+ (* piece-width col) left-margin col)
-                  y-pos (+ (* piece-height row) top-margin row)]]
+                  x-pos (+ (* piece-width-height col) left-margin col)
+                  y-pos (+ (* piece-width-height row) top-margin row)]]
       (let [piece (.sprite
                     game-object-factory
                     x-pos
@@ -100,8 +99,8 @@
         (and (zero? col) (= row (dec row-col-num)))
         (let [bottom-left-button (.sprite
                                    game-object-factory
-                                   (- x-pos piece-width)
-                                   (+ y-pos piece-height)
+                                   (- x-pos piece-width-height)
+                                   (+ y-pos piece-width-height)
                                    "flip-buttons"
                                    5)
               flip-diagonal-pieces! (fn []
@@ -120,7 +119,7 @@
       (when (zero? col)
         (let [left-button (.sprite
                                    game-object-factory
-                                   (- x-pos piece-width)
+                                   (- x-pos piece-width-height)
                                    y-pos
                                    "flip-buttons"
                                    row)
@@ -140,7 +139,7 @@
         (let [bottom-button (.sprite
                               game-object-factory
                               x-pos
-                              (+ y-pos piece-height)
+                              (+ y-pos piece-width-height)
                               "flip-buttons"
                               col)
               flip-col! (fn []

--- a/src/cljs/hello_world/core.cljs
+++ b/src/cljs/hello_world/core.cljs
@@ -40,18 +40,18 @@
     (get-button-height @button-sprite-sheet-height)
     6))
 
+(defn- make-buttons-same-size-as-puzzle-piece! [sprite]
+  (let [piece-width-height (get-piece-width-height (:puzzle-width-height @util/game-state))]
+    (.setTo
+      (.-scale sprite)
+      (/ piece-width-height (get-button-width @button-sprite-sheet-width))
+      (/ piece-width-height (get-button-height @button-sprite-sheet-height)))))
+
 (defn- create []
   (let [game-object-factory (.-add @util/game)
         left-margin (left-margin (:puzzle-width-height @util/game-state))
         top-margin (top-margin (:puzzle-width-height @util/game-state))
         piece-width-height (get-piece-width-height (:puzzle-width-height @util/game-state))
-        button-width (get-button-width @button-sprite-sheet-width)
-        button-height (get-button-height @button-sprite-sheet-height)
-        make-buttons-same-size-as-puzzle-piece! (fn [sprite]
-                                                  (.setTo
-                                                    (.-scale sprite)
-                                                    (/ piece-width-height button-width)
-                                                    (/ piece-width-height button-height)))
         set-on-click-callback! (fn [sprite callback-fn]
                                  (set! (.-inputEnabled sprite) true)
                                  (.add

--- a/src/cljs/hello_world/game.cljs
+++ b/src/cljs/hello_world/game.cljs
@@ -110,8 +110,7 @@
                 (println "bottom-left-button clicked")
                 (flip-diagonal-pieces!)
                 (send-sprites-state-fn!)
-                (util/show-congrat-message-when-puzzle-is-complete!)))
-            (randomly-execute-a-fn flip-diagonal-pieces!)))
+                (util/show-congrat-message-when-puzzle-is-complete!)))))
         (when (zero? col)
           (let [left-button (.sprite
                               game-object-factory
@@ -126,8 +125,7 @@
                 (println (str "left-button row #" row " clicked"))
                 (flip-row! row)
                 (send-sprites-state-fn!)
-                (util/show-congrat-message-when-puzzle-is-complete!)))
-            (randomly-execute-a-fn (fn [] (js/setTimeout (fn [] (flip-row! row)) 200)))))
+                (util/show-congrat-message-when-puzzle-is-complete!)))))
         (when (= row (dec row-col-num))
           (let [bottom-button (.sprite
                                 game-object-factory
@@ -142,8 +140,11 @@
                 (println (str "bottom-button col #" col " clicked"))
                 (flip-col! col)
                 (send-sprites-state-fn!)
-                (util/show-congrat-message-when-puzzle-is-complete!)))
-            (randomly-execute-a-fn (fn [] (js/setTimeout (fn [] (flip-col! col)) 200)))))))
+                (util/show-congrat-message-when-puzzle-is-complete!))))))
+      (randomly-execute-a-fn flip-diagonal-pieces!)
+      (doseq [row-or-col (range row-col-num)]
+        (randomly-execute-a-fn (fn [] (js/setTimeout (fn [] (flip-row! row-or-col)) 200)))
+        (randomly-execute-a-fn (fn [] (js/setTimeout (fn [] (flip-col! row-or-col)) 200)))))
     (js/setTimeout send-sprites-state-fn! 300)))
 
 (defn- update [])

--- a/src/cljs/hello_world/game.cljs
+++ b/src/cljs/hello_world/game.cljs
@@ -3,11 +3,6 @@
 
 (def row-col-num 5)
 
-(defn- left-margin [puzzle-width]
-  (/ (- (.-innerWidth js/window) puzzle-width) 2))
-(defn- top-margin [puzzle-height]
-  (/ (- (.-innerHeight js/window) puzzle-height) 4))
-
 (defn- get-piece-width-height [puzzle-width-height]
   (/ puzzle-width-height row-col-num))
 
@@ -41,8 +36,8 @@
 (defn- create-create [send-sprites-state-fn!]
   (fn []
     (let [game-object-factory (.-add @util/game)
-          left-margin (left-margin (:puzzle-width-height @util/game-state))
-          top-margin (top-margin (:puzzle-width-height @util/game-state))
+          left-margin (util/left-margin)
+          top-margin (util/top-margin)
           piece-width-height (get-piece-width-height (:puzzle-width-height @util/game-state))
           set-on-click-callback! (fn [sprite callback-fn]
                                    (set! (.-inputEnabled sprite) true)

--- a/src/cljs/hello_world/game.cljs
+++ b/src/cljs/hello_world/game.cljs
@@ -1,0 +1,161 @@
+(ns hello-world.game
+  (:require [hello-world.util :as util]
+            [hello-world.web-socket :as web-sck]))
+
+(def row-col-num 5)
+
+(defn- left-margin [puzzle-width]
+  (/ (- (.-innerWidth js/window) puzzle-width) 2))
+(defn- top-margin [puzzle-height]
+  (/ (- (.-innerHeight js/window) puzzle-height) 4))
+
+(defn- get-piece-width-height [puzzle-width-height]
+  (/ puzzle-width-height row-col-num))
+
+(defn- randomly-execute-a-fn [f]
+  (when (< (rand) 0.5) (f)))
+
+(defn- preload []
+  (.spritesheet
+    (.-load @util/game)
+    "puzzle"
+    "images/puzzle-image.jpg"
+    (get-piece-width-height @util/puzzle-image-width)
+    (get-piece-width-height @util/puzzle-image-height)
+    (* row-col-num row-col-num))
+  (.spritesheet
+    (.-load @util/game)
+    "flip-buttons"
+    "images/control-buttons.png"
+    (util/get-button-width)
+    (util/get-button-height)
+    6))
+
+(defn- make-buttons-same-size-as-puzzle-piece! [sprite]
+  (let [piece-width-height (get-piece-width-height (:puzzle-width-height @util/game-state))]
+    (.setTo
+      (.-scale sprite)
+      (/ piece-width-height (util/get-button-width))
+      (/ piece-width-height (util/get-button-height)))))
+
+(defn- create []
+  (let [game-object-factory (.-add @util/game)
+        left-margin (left-margin (:puzzle-width-height @util/game-state))
+        top-margin (top-margin (:puzzle-width-height @util/game-state))
+        piece-width-height (get-piece-width-height (:puzzle-width-height @util/game-state))
+        set-on-click-callback! (fn [sprite callback-fn]
+                                 (set! (.-inputEnabled sprite) true)
+                                 (.add
+                                   (.-onInputDown (.-events sprite))
+                                   callback-fn))
+        toggle-visibility-and-flipped-state! (fn [col row]
+                                               (let [piece-scale (.-scale ((:sprites @util/game-state) [col row]))]
+                                                 (if (zero? (.-x piece-scale))
+                                                   (do
+                                                     (swap!
+                                                       util/game-state
+                                                       update
+                                                       :sprites-state
+                                                       assoc
+                                                       [col row]
+                                                       util/non-flipped-state)
+                                                     (.setTo
+                                                       piece-scale
+                                                       (:piece-x-scale @util/game-state)
+                                                       (:piece-y-scale @util/game-state)))
+                                                   (do
+                                                     (swap!
+                                                       util/game-state
+                                                       update
+                                                       :sprites-state
+                                                       assoc
+                                                       [col row]
+                                                       util/flipped-state)
+                                                     (.setTo piece-scale 0 0)))))]
+    (doseq [row (range row-col-num)
+            col (range row-col-num)
+            :let [frame-id (+ (* row-col-num row) col)
+                  x-pos (+ (* piece-width-height col) left-margin col)
+                  y-pos (+ (* piece-width-height row) top-margin row)]]
+      (let [piece (.sprite
+                    game-object-factory
+                    x-pos
+                    y-pos
+                    "puzzle"
+                    frame-id)]
+        (swap! util/game-state update :sprites assoc [col row] piece)
+        (swap! util/game-state update :sprites-state assoc [col row] util/non-flipped-state)
+        (.setTo (.-scale piece) (:piece-x-scale @util/game-state) (:piece-y-scale @util/game-state)))
+      (when
+        (and (zero? col) (= row (dec row-col-num)))
+        (let [bottom-left-button (.sprite
+                                   game-object-factory
+                                   (- x-pos piece-width-height)
+                                   (+ y-pos piece-width-height)
+                                   "flip-buttons"
+                                   5)
+              flip-diagonal-pieces! (fn []
+                                      (doseq [row (range row-col-num)
+                                              :let [col (- (dec row-col-num) row)]]
+                                        (toggle-visibility-and-flipped-state! col row)))]
+          (make-buttons-same-size-as-puzzle-piece! bottom-left-button)
+          (set-on-click-callback!
+            bottom-left-button
+            (fn []
+              (println "bottom-left-button clicked")
+              (flip-diagonal-pieces!)
+              (web-sck/send-sprites-state!)
+              (util/show-congrat-message-when-puzzle-is-complete!)))
+          (randomly-execute-a-fn flip-diagonal-pieces!)))
+      (when (zero? col)
+        (let [left-button (.sprite
+                            game-object-factory
+                            (- x-pos piece-width-height)
+                            y-pos
+                            "flip-buttons"
+                            row)
+              flip-row! (fn []
+                          (doseq [col (range row-col-num)]
+                            (toggle-visibility-and-flipped-state! col row)))]
+          (make-buttons-same-size-as-puzzle-piece! left-button)
+          (set-on-click-callback!
+            left-button
+            (fn []
+              (println (str "left-button row #" row " clicked"))
+              (flip-row!)
+              (web-sck/send-sprites-state!)
+              (util/show-congrat-message-when-puzzle-is-complete!)))
+          (randomly-execute-a-fn (fn [] (js/setTimeout flip-row! 200)))))
+      (when (= row (dec row-col-num))
+        (let [bottom-button (.sprite
+                              game-object-factory
+                              x-pos
+                              (+ y-pos piece-width-height)
+                              "flip-buttons"
+                              col)
+              flip-col! (fn []
+                          (doseq [row (range row-col-num)]
+                            (toggle-visibility-and-flipped-state! col row)))]
+          (make-buttons-same-size-as-puzzle-piece! bottom-button)
+          (set-on-click-callback!
+            bottom-button
+            (fn []
+              (println (str "bottom-button col #" col " clicked"))
+              (flip-col!)
+              (web-sck/send-sprites-state!)
+              (util/show-congrat-message-when-puzzle-is-complete!)))
+          (randomly-execute-a-fn (fn [] (js/setTimeout flip-col! 200)))))))
+  (js/setTimeout web-sck/send-sprites-state! 300))
+
+(defn- update [])
+
+(defn- start-game! []
+  (println "starting game")
+  (reset! util/game
+          (js/Phaser.Game.
+            (.-innerWidth js/window)
+            (.-innerHeight js/window)
+            js/Phaser.Auto
+            ""
+            ; ^ id of the DOM element to insert canvas. As we've left it blank it will simply be appended to body.
+            (clj->js {:preload preload :create create :update update}))))

--- a/src/cljs/hello_world/game.cljs
+++ b/src/cljs/hello_world/game.cljs
@@ -32,6 +32,43 @@
       (/ piece-width-height (util/get-button-width))
       (/ piece-width-height (util/get-button-height)))))
 
+(defn- toggle-visibility-and-flipped-state! [col row]
+  (let [piece-scale (.-scale ((:sprites @util/game-state) [col row]))]
+    (if (zero? (.-x piece-scale))
+      (do
+        (swap!
+          util/game-state
+          update
+          :sprites-state
+          assoc
+          [col row]
+          util/non-flipped-state)
+        (.setTo
+          piece-scale
+          (:piece-x-scale @util/game-state)
+          (:piece-y-scale @util/game-state)))
+      (do
+        (swap!
+          util/game-state
+          update
+          :sprites-state
+          assoc
+          [col row]
+          util/flipped-state)
+        (.setTo piece-scale 0 0)))))
+
+(defn flip-row! [row]
+  (doseq [col (range row-col-num)]
+    (toggle-visibility-and-flipped-state! col row)))
+
+(defn flip-col! [col]
+  (doseq [row (range row-col-num)]
+    (toggle-visibility-and-flipped-state! col row)))
+
+(defn flip-diagonal-pieces! []
+  (doseq [row (range row-col-num)
+          :let [col (- (dec row-col-num) row)]]
+    (toggle-visibility-and-flipped-state! col row)))
 
 (defn- create-create [send-sprites-state-fn!]
   (fn []
@@ -43,31 +80,7 @@
                                    (set! (.-inputEnabled sprite) true)
                                    (.add
                                      (.-onInputDown (.-events sprite))
-                                     callback-fn))
-          toggle-visibility-and-flipped-state! (fn [col row]
-                                                 (let [piece-scale (.-scale ((:sprites @util/game-state) [col row]))]
-                                                   (if (zero? (.-x piece-scale))
-                                                     (do
-                                                       (swap!
-                                                         util/game-state
-                                                         update
-                                                         :sprites-state
-                                                         assoc
-                                                         [col row]
-                                                         util/non-flipped-state)
-                                                       (.setTo
-                                                         piece-scale
-                                                         (:piece-x-scale @util/game-state)
-                                                         (:piece-y-scale @util/game-state)))
-                                                     (do
-                                                       (swap!
-                                                         util/game-state
-                                                         update
-                                                         :sprites-state
-                                                         assoc
-                                                         [col row]
-                                                         util/flipped-state)
-                                                       (.setTo piece-scale 0 0)))))]
+                                     callback-fn))]
       (doseq [row (range row-col-num)
               col (range row-col-num)
               :let [frame-id (+ (* row-col-num row) col)
@@ -89,11 +102,7 @@
                                      (- x-pos piece-width-height)
                                      (+ y-pos piece-width-height)
                                      "flip-buttons"
-                                     5)
-                flip-diagonal-pieces! (fn []
-                                        (doseq [row (range row-col-num)
-                                                :let [col (- (dec row-col-num) row)]]
-                                          (toggle-visibility-and-flipped-state! col row)))]
+                                     5)]
             (make-buttons-same-size-as-puzzle-piece! bottom-left-button)
             (set-on-click-callback!
               bottom-left-button
@@ -109,38 +118,32 @@
                               (- x-pos piece-width-height)
                               y-pos
                               "flip-buttons"
-                              row)
-                flip-row! (fn []
-                            (doseq [col (range row-col-num)]
-                              (toggle-visibility-and-flipped-state! col row)))]
+                              row)]
             (make-buttons-same-size-as-puzzle-piece! left-button)
             (set-on-click-callback!
               left-button
               (fn []
                 (println (str "left-button row #" row " clicked"))
-                (flip-row!)
+                (flip-row! row)
                 (send-sprites-state-fn!)
                 (util/show-congrat-message-when-puzzle-is-complete!)))
-            (randomly-execute-a-fn (fn [] (js/setTimeout flip-row! 200)))))
+            (randomly-execute-a-fn (fn [] (js/setTimeout (fn [] (flip-row! row)) 200)))))
         (when (= row (dec row-col-num))
           (let [bottom-button (.sprite
                                 game-object-factory
                                 x-pos
                                 (+ y-pos piece-width-height)
                                 "flip-buttons"
-                                col)
-                flip-col! (fn []
-                            (doseq [row (range row-col-num)]
-                              (toggle-visibility-and-flipped-state! col row)))]
+                                col)]
             (make-buttons-same-size-as-puzzle-piece! bottom-button)
             (set-on-click-callback!
               bottom-button
               (fn []
                 (println (str "bottom-button col #" col " clicked"))
-                (flip-col!)
+                (flip-col! col)
                 (send-sprites-state-fn!)
                 (util/show-congrat-message-when-puzzle-is-complete!)))
-            (randomly-execute-a-fn (fn [] (js/setTimeout flip-col! 200)))))))
+            (randomly-execute-a-fn (fn [] (js/setTimeout (fn [] (flip-col! col)) 200)))))))
     (js/setTimeout send-sprites-state-fn! 300)))
 
 (defn- update [])

--- a/src/cljs/hello_world/game.cljs
+++ b/src/cljs/hello_world/game.cljs
@@ -70,6 +70,12 @@
           :let [col (- (dec row-col-num) row)]]
     (toggle-visibility-and-flipped-state! col row)))
 
+(defn- randomize-puzzle []
+  (randomly-execute-a-fn flip-diagonal-pieces!)
+  (doseq [row-or-col (range row-col-num)]
+    (randomly-execute-a-fn (fn [] (js/setTimeout (fn [] (flip-row! row-or-col)) 200)))
+    (randomly-execute-a-fn (fn [] (js/setTimeout (fn [] (flip-col! row-or-col)) 200)))))
+
 (defn- create-create [send-sprites-state-fn!]
   (fn []
     (let [game-object-factory (.-add @util/game)
@@ -141,10 +147,7 @@
                 (flip-col! col)
                 (send-sprites-state-fn!)
                 (util/show-congrat-message-when-puzzle-is-complete!))))))
-      (randomly-execute-a-fn flip-diagonal-pieces!)
-      (doseq [row-or-col (range row-col-num)]
-        (randomly-execute-a-fn (fn [] (js/setTimeout (fn [] (flip-row! row-or-col)) 200)))
-        (randomly-execute-a-fn (fn [] (js/setTimeout (fn [] (flip-col! row-or-col)) 200)))))
+      (randomize-puzzle))
     (js/setTimeout send-sprites-state-fn! 300)))
 
 (defn- update [])

--- a/src/cljs/hello_world/game.cljs
+++ b/src/cljs/hello_world/game.cljs
@@ -1,6 +1,5 @@
 (ns hello-world.game
-  (:require [hello-world.util :as util]
-            [hello-world.web-socket :as web-sck]))
+  (:require [hello-world.util :as util]))
 
 (def row-col-num 5)
 
@@ -38,118 +37,120 @@
       (/ piece-width-height (util/get-button-width))
       (/ piece-width-height (util/get-button-height)))))
 
-(defn- create []
-  (let [game-object-factory (.-add @util/game)
-        left-margin (left-margin (:puzzle-width-height @util/game-state))
-        top-margin (top-margin (:puzzle-width-height @util/game-state))
-        piece-width-height (get-piece-width-height (:puzzle-width-height @util/game-state))
-        set-on-click-callback! (fn [sprite callback-fn]
-                                 (set! (.-inputEnabled sprite) true)
-                                 (.add
-                                   (.-onInputDown (.-events sprite))
-                                   callback-fn))
-        toggle-visibility-and-flipped-state! (fn [col row]
-                                               (let [piece-scale (.-scale ((:sprites @util/game-state) [col row]))]
-                                                 (if (zero? (.-x piece-scale))
-                                                   (do
-                                                     (swap!
-                                                       util/game-state
-                                                       update
-                                                       :sprites-state
-                                                       assoc
-                                                       [col row]
-                                                       util/non-flipped-state)
-                                                     (.setTo
-                                                       piece-scale
-                                                       (:piece-x-scale @util/game-state)
-                                                       (:piece-y-scale @util/game-state)))
-                                                   (do
-                                                     (swap!
-                                                       util/game-state
-                                                       update
-                                                       :sprites-state
-                                                       assoc
-                                                       [col row]
-                                                       util/flipped-state)
-                                                     (.setTo piece-scale 0 0)))))]
-    (doseq [row (range row-col-num)
-            col (range row-col-num)
-            :let [frame-id (+ (* row-col-num row) col)
-                  x-pos (+ (* piece-width-height col) left-margin col)
-                  y-pos (+ (* piece-width-height row) top-margin row)]]
-      (let [piece (.sprite
-                    game-object-factory
-                    x-pos
-                    y-pos
-                    "puzzle"
-                    frame-id)]
-        (swap! util/game-state update :sprites assoc [col row] piece)
-        (swap! util/game-state update :sprites-state assoc [col row] util/non-flipped-state)
-        (.setTo (.-scale piece) (:piece-x-scale @util/game-state) (:piece-y-scale @util/game-state)))
-      (when
-        (and (zero? col) (= row (dec row-col-num)))
-        (let [bottom-left-button (.sprite
-                                   game-object-factory
-                                   (- x-pos piece-width-height)
-                                   (+ y-pos piece-width-height)
-                                   "flip-buttons"
-                                   5)
-              flip-diagonal-pieces! (fn []
-                                      (doseq [row (range row-col-num)
-                                              :let [col (- (dec row-col-num) row)]]
-                                        (toggle-visibility-and-flipped-state! col row)))]
-          (make-buttons-same-size-as-puzzle-piece! bottom-left-button)
-          (set-on-click-callback!
-            bottom-left-button
-            (fn []
-              (println "bottom-left-button clicked")
-              (flip-diagonal-pieces!)
-              (web-sck/send-sprites-state!)
-              (util/show-congrat-message-when-puzzle-is-complete!)))
-          (randomly-execute-a-fn flip-diagonal-pieces!)))
-      (when (zero? col)
-        (let [left-button (.sprite
-                            game-object-factory
-                            (- x-pos piece-width-height)
-                            y-pos
-                            "flip-buttons"
-                            row)
-              flip-row! (fn []
-                          (doseq [col (range row-col-num)]
-                            (toggle-visibility-and-flipped-state! col row)))]
-          (make-buttons-same-size-as-puzzle-piece! left-button)
-          (set-on-click-callback!
-            left-button
-            (fn []
-              (println (str "left-button row #" row " clicked"))
-              (flip-row!)
-              (web-sck/send-sprites-state!)
-              (util/show-congrat-message-when-puzzle-is-complete!)))
-          (randomly-execute-a-fn (fn [] (js/setTimeout flip-row! 200)))))
-      (when (= row (dec row-col-num))
-        (let [bottom-button (.sprite
+
+(defn- create-create [send-sprites-state-fn!]
+  (fn []
+    (let [game-object-factory (.-add @util/game)
+          left-margin (left-margin (:puzzle-width-height @util/game-state))
+          top-margin (top-margin (:puzzle-width-height @util/game-state))
+          piece-width-height (get-piece-width-height (:puzzle-width-height @util/game-state))
+          set-on-click-callback! (fn [sprite callback-fn]
+                                   (set! (.-inputEnabled sprite) true)
+                                   (.add
+                                     (.-onInputDown (.-events sprite))
+                                     callback-fn))
+          toggle-visibility-and-flipped-state! (fn [col row]
+                                                 (let [piece-scale (.-scale ((:sprites @util/game-state) [col row]))]
+                                                   (if (zero? (.-x piece-scale))
+                                                     (do
+                                                       (swap!
+                                                         util/game-state
+                                                         update
+                                                         :sprites-state
+                                                         assoc
+                                                         [col row]
+                                                         util/non-flipped-state)
+                                                       (.setTo
+                                                         piece-scale
+                                                         (:piece-x-scale @util/game-state)
+                                                         (:piece-y-scale @util/game-state)))
+                                                     (do
+                                                       (swap!
+                                                         util/game-state
+                                                         update
+                                                         :sprites-state
+                                                         assoc
+                                                         [col row]
+                                                         util/flipped-state)
+                                                       (.setTo piece-scale 0 0)))))]
+      (doseq [row (range row-col-num)
+              col (range row-col-num)
+              :let [frame-id (+ (* row-col-num row) col)
+                    x-pos (+ (* piece-width-height col) left-margin col)
+                    y-pos (+ (* piece-width-height row) top-margin row)]]
+        (let [piece (.sprite
+                      game-object-factory
+                      x-pos
+                      y-pos
+                      "puzzle"
+                      frame-id)]
+          (swap! util/game-state update :sprites assoc [col row] piece)
+          (swap! util/game-state update :sprites-state assoc [col row] util/non-flipped-state)
+          (.setTo (.-scale piece) (:piece-x-scale @util/game-state) (:piece-y-scale @util/game-state)))
+        (when
+          (and (zero? col) (= row (dec row-col-num)))
+          (let [bottom-left-button (.sprite
+                                     game-object-factory
+                                     (- x-pos piece-width-height)
+                                     (+ y-pos piece-width-height)
+                                     "flip-buttons"
+                                     5)
+                flip-diagonal-pieces! (fn []
+                                        (doseq [row (range row-col-num)
+                                                :let [col (- (dec row-col-num) row)]]
+                                          (toggle-visibility-and-flipped-state! col row)))]
+            (make-buttons-same-size-as-puzzle-piece! bottom-left-button)
+            (set-on-click-callback!
+              bottom-left-button
+              (fn []
+                (println "bottom-left-button clicked")
+                (flip-diagonal-pieces!)
+                (send-sprites-state-fn!)
+                (util/show-congrat-message-when-puzzle-is-complete!)))
+            (randomly-execute-a-fn flip-diagonal-pieces!)))
+        (when (zero? col)
+          (let [left-button (.sprite
                               game-object-factory
-                              x-pos
-                              (+ y-pos piece-width-height)
+                              (- x-pos piece-width-height)
+                              y-pos
                               "flip-buttons"
-                              col)
-              flip-col! (fn []
-                          (doseq [row (range row-col-num)]
-                            (toggle-visibility-and-flipped-state! col row)))]
-          (make-buttons-same-size-as-puzzle-piece! bottom-button)
-          (set-on-click-callback!
-            bottom-button
-            (fn []
-              (println (str "bottom-button col #" col " clicked"))
-              (flip-col!)
-              (web-sck/send-sprites-state!)
-              (util/show-congrat-message-when-puzzle-is-complete!)))
-          (randomly-execute-a-fn (fn [] (js/setTimeout flip-col! 200)))))))
-  (js/setTimeout web-sck/send-sprites-state! 300))
+                              row)
+                flip-row! (fn []
+                            (doseq [col (range row-col-num)]
+                              (toggle-visibility-and-flipped-state! col row)))]
+            (make-buttons-same-size-as-puzzle-piece! left-button)
+            (set-on-click-callback!
+              left-button
+              (fn []
+                (println (str "left-button row #" row " clicked"))
+                (flip-row!)
+                (send-sprites-state-fn!)
+                (util/show-congrat-message-when-puzzle-is-complete!)))
+            (randomly-execute-a-fn (fn [] (js/setTimeout flip-row! 200)))))
+        (when (= row (dec row-col-num))
+          (let [bottom-button (.sprite
+                                game-object-factory
+                                x-pos
+                                (+ y-pos piece-width-height)
+                                "flip-buttons"
+                                col)
+                flip-col! (fn []
+                            (doseq [row (range row-col-num)]
+                              (toggle-visibility-and-flipped-state! col row)))]
+            (make-buttons-same-size-as-puzzle-piece! bottom-button)
+            (set-on-click-callback!
+              bottom-button
+              (fn []
+                (println (str "bottom-button col #" col " clicked"))
+                (flip-col!)
+                (send-sprites-state-fn!)
+                (util/show-congrat-message-when-puzzle-is-complete!)))
+            (randomly-execute-a-fn (fn [] (js/setTimeout flip-col! 200)))))))
+    (js/setTimeout send-sprites-state-fn! 300)))
 
 (defn- update [])
 
-(defn- start-game! []
+(defn- start-game! [send-sprites-state-fn!]
   (println "starting game")
   (reset! util/game
           (js/Phaser.Game.
@@ -158,4 +159,4 @@
             js/Phaser.Auto
             ""
             ; ^ id of the DOM element to insert canvas. As we've left it blank it will simply be appended to body.
-            (clj->js {:preload preload :create create :update update}))))
+            (clj->js {:preload preload :create (create-create send-sprites-state-fn!) :update update}))))

--- a/src/cljs/hello_world/game.cljs
+++ b/src/cljs/hello_world/game.cljs
@@ -76,7 +76,7 @@
     (randomly-execute-a-fn (fn [] (js/setTimeout (fn [] (flip-row! row-or-col)) 200)))
     (randomly-execute-a-fn (fn [] (js/setTimeout (fn [] (flip-col! row-or-col)) 200)))))
 
-(defn- create-create [send-sprites-state-fn!]
+(defn- create-create [send-sprites-state-fn! initial-sprites-state]
   (fn []
     (let [game-object-factory (.-add @util/game)
           left-margin (util/left-margin)
@@ -147,12 +147,15 @@
                 (flip-col! col)
                 (send-sprites-state-fn!)
                 (util/show-congrat-message-when-puzzle-is-complete!))))))
-      (randomize-puzzle))
-    (js/setTimeout send-sprites-state-fn! 300)))
+      (if (nil? initial-sprites-state)
+        (do
+          (randomize-puzzle)
+          (js/setTimeout send-sprites-state-fn! 300))
+        (util/synchronize-puzzle-board initial-sprites-state)))))
 
 (defn- update [])
 
-(defn- start-game! [send-sprites-state-fn!]
+(defn- start-game! [send-sprites-state-fn! initial-sprites-state]
   (println "starting game")
   (reset! util/game
           (js/Phaser.Game.
@@ -161,4 +164,6 @@
             js/Phaser.Auto
             ""
             ; ^ id of the DOM element to insert canvas. As we've left it blank it will simply be appended to body.
-            (clj->js {:preload preload :create (create-create send-sprites-state-fn!) :update update}))))
+            (clj->js {:preload preload
+                      :create  (create-create send-sprites-state-fn! initial-sprites-state)
+                      :update  update}))))

--- a/src/cljs/hello_world/util.cljs
+++ b/src/cljs/hello_world/util.cljs
@@ -49,3 +49,27 @@
              (clj->js {:font  "60px Arial"
                        :fill  "#ffffff"
                        :align "center"})))))
+
+(defn- synchronize-puzzle-board [sprites-state]
+  (println "synchronizing")
+  (let [derefed-state @game-state
+        piece-x-scale (:piece-x-scale derefed-state)
+        piece-y-scale (:piece-y-scale derefed-state)
+        sprites (:sprites derefed-state)]
+    (doseq [[[col row] sprite-flipped-state] sprites-state]
+      (let [piece-scale (.-scale (sprites [col row]))]
+        (if (= non-flipped-state sprite-flipped-state)
+          (do
+            (swap!
+              game-state
+              assoc-in
+              [:sprites-state [col row]]
+              non-flipped-state)
+            (.setTo piece-scale piece-x-scale piece-y-scale))
+          (do
+            (swap!
+              game-state
+              assoc-in
+              [:sprites-state [col row]]
+              flipped-state)
+            (.setTo piece-scale 0 0)))))))

--- a/src/cljs/hello_world/util.cljs
+++ b/src/cljs/hello_world/util.cljs
@@ -29,6 +29,12 @@
 (defn- get-button-height []
   (/ @button-sprite-sheet-height 2))
 
+(defn- left-margin []
+  (/ (- (.-innerWidth js/window) (:puzzle-width-height @game-state)) 2))
+
+(defn- top-margin []
+  (/ (- (.-innerHeight js/window) (:puzzle-width-height @game-state)) 4))
+
 (defn show-congrat-message-when-puzzle-is-complete! []
   (when (and (every? #(= non-flipped-state (val %)) (:sprites-state @game-state))
              (not (:stage-clear-text @game-state)))

--- a/src/cljs/hello_world/util.cljs
+++ b/src/cljs/hello_world/util.cljs
@@ -12,7 +12,22 @@
                            :stage-clear-text    nil}))
 
 (def flipped-state "FLIPPED")
+
 (def non-flipped-state "NON-FLIPPED")
+
+(def puzzle-image-width (atom nil))
+
+(def puzzle-image-height (atom nil))
+
+(def button-sprite-sheet-width (atom nil))
+
+(def button-sprite-sheet-height (atom nil))
+
+(defn- get-button-width []
+  (/ @button-sprite-sheet-width 3))
+
+(defn- get-button-height []
+  (/ @button-sprite-sheet-height 2))
 
 (defn show-congrat-message-when-puzzle-is-complete! []
   (when (and (every? #(= non-flipped-state (val %)) (:sprites-state @game-state))

--- a/src/cljs/hello_world/web_socket.cljs
+++ b/src/cljs/hello_world/web_socket.cljs
@@ -42,7 +42,7 @@
 
       :aikakone/game-start (do
                              (println "Start game with initial state " event-data)
-                             (game/start-game! send-sprites-state!))
+                             (game/start-game! send-sprites-state! event-data))
       (println event-id " is unknown event type"))))
 
 (defn send-uid []

--- a/src/cljs/hello_world/web_socket.cljs
+++ b/src/cljs/hello_world/web_socket.cljs
@@ -22,7 +22,7 @@
   (println "sending " (:sprites-state @util/game-state))
   (chsk-send! [:aikakone/sprites-state (:sprites-state @util/game-state)]))
 
-(defn- syncronize-puzzle-board [sprites-state]
+(defn- synchronize-puzzle-board [sprites-state]
   (let [derefed-state @util/game-state
         piece-x-scale (:piece-x-scale derefed-state)
         piece-y-scale (:piece-y-scale derefed-state)
@@ -60,7 +60,7 @@
     (println "received " [event-id event-data])
     (case event-id
       :aikakone/sprites-state (do
-                                (syncronize-puzzle-board event-data)
+                                (synchronize-puzzle-board event-data)
                                 (util/show-congrat-message-when-puzzle-is-complete!))
 
       :aikakone/game-start (do

--- a/src/cljs/hello_world/web_socket.cljs
+++ b/src/cljs/hello_world/web_socket.cljs
@@ -1,7 +1,7 @@
 (ns hello-world.web-socket
-  (:require [taoensso.sente  :as sente :refer (cb-success?)]
+  (:require [taoensso.sente :as sente :refer (cb-success?)]
             [hello-world.util :as util]
-            ))
+            [hello-world.game :as game]))
 
 (defn get-chsk-url
   "Connect to a configured server instead of the page host"
@@ -65,7 +65,8 @@
                                 (util/show-congrat-message-when-puzzle-is-complete!))
 
       :aikakone/game-start (do
-                             (println "Start game with initial state " event-data))
+                             (println "Start game with initial state " event-data)
+                             (game/start-game! send-sprites-state!))
       (println event-id " is unknown event type"))))
 
 (defn send-uid []
@@ -78,4 +79,5 @@
     (chsk-send! [:aikakone/game-start])
     (send-uid)))
 
-(sente/start-chsk-router! ch-chsk event-msg-handler)
+(defn start-web-socket! []
+  (sente/start-chsk-router! ch-chsk event-msg-handler))

--- a/src/cljs/hello_world/web_socket.cljs
+++ b/src/cljs/hello_world/web_socket.cljs
@@ -23,6 +23,7 @@
   (chsk-send! [:aikakone/sprites-state (:sprites-state @util/game-state)]))
 
 (defn- synchronize-puzzle-board [sprites-state]
+  (println "synchronizing")
   (let [derefed-state @util/game-state
         piece-x-scale (:piece-x-scale derefed-state)
         piece-y-scale (:piece-y-scale derefed-state)

--- a/src/cljs/hello_world/web_socket.cljs
+++ b/src/cljs/hello_world/web_socket.cljs
@@ -62,6 +62,9 @@
       :aikakone/sprites-state (do
                                 (syncronize-puzzle-board event-data)
                                 (util/show-congrat-message-when-puzzle-is-complete!))
+
+      :aikakone/game-start (do
+                             (println "Start game with initial state " event-data))
       (println event-id " is unknown event type"))))
 
 (defn send-uid []
@@ -71,6 +74,7 @@
   (let [[?uid ?csrf-token ?handshake-data] ?data]
     (println "Handshake:" ?data)
     (swap! util/game-state assoc :uid ?uid)
+    (chsk-send! [:aikakone/game-start])
     (send-uid)))
 
 (sente/start-chsk-router! ch-chsk event-msg-handler)

--- a/src/cljs/hello_world/web_socket.cljs
+++ b/src/cljs/hello_world/web_socket.cljs
@@ -22,30 +22,6 @@
   (println "sending " (:sprites-state @util/game-state))
   (chsk-send! [:aikakone/sprites-state (:sprites-state @util/game-state)]))
 
-(defn- synchronize-puzzle-board [sprites-state]
-  (println "synchronizing")
-  (let [derefed-state @util/game-state
-        piece-x-scale (:piece-x-scale derefed-state)
-        piece-y-scale (:piece-y-scale derefed-state)
-        sprites (:sprites derefed-state)]
-    (doseq [[[col row] sprite-flipped-state] sprites-state]
-      (let [piece-scale (.-scale (sprites [col row]))]
-        (if (= util/non-flipped-state sprite-flipped-state)
-          (do
-            (swap!
-              util/game-state
-              assoc-in
-              [:sprites-state [col row]]
-              util/non-flipped-state)
-            (.setTo piece-scale piece-x-scale piece-y-scale))
-          (do
-            (swap!
-              util/game-state
-              assoc-in
-              [:sprites-state [col row]]
-              util/flipped-state)
-            (.setTo piece-scale 0 0)))))))
-
 (defmulti event-msg-handler :id)
 
 (defmethod event-msg-handler :default [{:keys [event]}]
@@ -61,7 +37,7 @@
     (println "received " [event-id event-data])
     (case event-id
       :aikakone/sprites-state (do
-                                (synchronize-puzzle-board event-data)
+                                (util/synchronize-puzzle-board event-data)
                                 (util/show-congrat-message-when-puzzle-is-complete!))
 
       :aikakone/game-start (do


### PR DESCRIPTION
synchronize the puzzle state between clients on game start

A lot of refactorings...
This was tricky to do it and at first I was stuck because of circular dependency,
finally I am finishing this feature.

To start puzzle with existing state that's already stored in server,
web-socket needs to get the state after handshake, and then it should start the game.
So web-socket ns needs game ns to call `start-game!` function. However,
game ns needs web-socket to send the sprites state. This mutual dependency is not allowed in Clojure. But putting everything in util or in one ns is ofc bad practice.
I solved this by passing `send-sprites-state!` function as an argument to when web-sck ns calls `game-start!`. This can be a general solution when encounters circular dependency.

In summary, when encounters circular dependency require one from another and pass needed stuff as an argument.

Once I figured this out, the rest was breeze.